### PR TITLE
Added hashCheck=true to tempalte files of mixedops, randomops, seqops

### DIFF
--- a/XMLtemplates/TMPL_mixedops.xml
+++ b/XMLtemplates/TMPL_mixedops.xml
@@ -7,8 +7,8 @@
 
     <workstage name="mainmixed">
       <work name="main" workers="MIXEDworkers" division="object" runtime="THEruntime">
-        <operation type="read" ratio="MIXEDrdRatio" config="cprefix=THEcprefix;MIXEDrdConf" />
-        <operation type="list" ratio="MIXEDlistRatio" config="cprefix=THEcprefix;MIXEDlistConf" />
+        <operation type="read" ratio="MIXEDrdRatio" config="cprefix=THEcprefix;MIXEDrdConf;hashCheck=true" />
+        <operation type="list" ratio="MIXEDlistRatio" config="cprefix=THEcprefix;MIXEDlistConf;hashCheck=true" />
         <operation type="write" ratio="MIXEDwrRatio" config="cprefix=THEcprefix;MIXEDwrConf;sizes=THEsizes" />
         <operation type="delete" ratio="14" config="cprefix=THEcprefix;MIXEDdelConf" />
       </work>

--- a/XMLtemplates/TMPL_randomops.xml
+++ b/XMLtemplates/TMPL_randomops.xml
@@ -7,7 +7,7 @@
 
     <workstage name="randread">
       <work name="randread" workers="RANDOMworkers" division="object" runtime="THEruntime">
-        <operation type="read" ratio="100" config="cprefix=THEcprefix;containers=u(1,THEnumCont);objects=u(1,THEnumObj)" />
+        <operation type="read" ratio="100" config="cprefix=THEcprefix;containers=u(1,THEnumCont);objects=u(1,THEnumObj);hashCheck=true" />
       </work>
     </workstage>
 

--- a/XMLtemplates/TMPL_seqops.xml
+++ b/XMLtemplates/TMPL_seqops.xml
@@ -13,7 +13,7 @@
 
     <workstage name="seqread">
       <work name="seqread" workers="SEQworkers" division="object" runtime="THEruntime">
-        <operation type="read" ratio="100" config="cprefix=THEcprefix;containers=s(1,THEnumCont);objects=s(1,THEnumObj)" />
+        <operation type="read" ratio="100" config="cprefix=THEcprefix;containers=s(1,THEnumCont);objects=s(1,THEnumObj);hashCheck=true" />
       </work>
     </workstage>
 


### PR DESCRIPTION
Added hashCheck=true to tempalte files of mixedops, randomops, seqops since Cosbench was complaining about data integrity issues.

This is based on https://github.com/intel-cloud/cosbench/issues/320

Signed-off-by: Shekhar Berry <shberry@redhat.com>