### PR TITLE
Amended random and sequential template files to include write workstage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ FILENAME | Description
 -------- | -----------
 fill.xml | cluster fill workload (creates buckets and objects) **must be run as first workload**
 empty.xml | cluster empty (removes objects and buckets) **must be run as last workload**
-seqops.xml | performs sequential reads then writes
-randomops.xml | performs random reads then writes
+seqops.xml | performs sequential reads then writes. For writes it initializes new containers and perfoms write on them. Eventually it deletes and disposes these new containers and objects within it.
+randomops.xml | performs random reads then writes. For writes it initializes new containers and perfoms write on them. Eventually it deletes and disposes these new containers and objects within it.
 mixedops.xml | performs mixture of read, list, write, deletes
 
 Edit genXMLs.sh and set access key, secret key and endpoint

--- a/XMLtemplates/TMPL_randomops.xml
+++ b/XMLtemplates/TMPL_randomops.xml
@@ -11,10 +11,22 @@
       </work>
     </workstage>
 
+    <workstage name="init-containers">
+      <work type="init" workers="1" config="cprefix=THEcprefix;containers=r(NUMwrcontstart,NUMwrcontend)" />
+    </workstage> 
+
     <workstage name="randwr">
       <work name="randwr" workers="RANDOMworkers" division="object" runtime="THEruntime">
-        <operation type="write" ratio="100" config="cprefix=THEcprefix;containers=u(1,THEnumCont);objects=u(1,THEnumObj);sizes=THEsizes" />
+        <operation type="write" ratio="100" config="cprefix=THEcprefix;containers=u(NUMwrcontstart,NUMwrcontend);objects=u(1,THEnumObj);sizes=THEsizes" />
       </work>
+    </workstage>
+
+    <workstage name="cleanup">
+      <work type="cleanup" workers="FILLworkers" config="cprefix=THEcprefix;containers=r(NUMwrcontstart,NUMwrcontend);objects=r(1,THEmaxNumObj)" />
+    </workstage>
+
+    <workstage name="dispose">
+      <work type="dispose" workers="1" config="cprefix=THEcprefix;containers=r(NUMwrcontstart,NUMwrcontend)" />
     </workstage>
 
   </workflow>

--- a/XMLtemplates/TMPL_seqops.xml
+++ b/XMLtemplates/TMPL_seqops.xml
@@ -1,20 +1,32 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<workload name="seqOps" description="sequential write then read">
+<workload name="seqOps" description="sequential read then write">
 
   <storage type="s3" config="THEauth" />
 
   <workflow>
 
-    <workstage name="seqwrite">
-      <work name="seqwrite" workers="SEQworkers" division="object" runtime="THEruntime">
-        <operation type="write" ratio="100" config="cprefix=THEcprefix;containers=s(1,THEnumCont);objects=s(1,THEnumObj);sizes=THEsizes" />
-      </work>
-    </workstage>
-
     <workstage name="seqread">
       <work name="seqread" workers="SEQworkers" division="object" runtime="THEruntime">
         <operation type="read" ratio="100" config="cprefix=THEcprefix;containers=s(1,THEnumCont);objects=s(1,THEnumObj);hashCheck=true" />
       </work>
+    </workstage>
+
+     <workstage name="init-containers">
+      <work type="init" workers="1" config="cprefix=THEcprefix;containers=r(NUMwrcontstart,NUMwrcontend)" />
+    </workstage> 
+
+    <workstage name="seqwrite">
+      <work name="seqwrite" workers="SEQworkers" division="object" runtime="THEruntime">
+        <operation type="write" ratio="100" config="cprefix=THEcprefix;containers=s(NUMwrcontstart,NUMwrcontend);objects=s(1,THEnumObj);sizes=THEsizes" />
+      </work>
+    </workstage>
+
+    <workstage name="cleanup">
+      <work type="cleanup" workers="FILLworkers" config="cprefix=THEcprefix;containers=r(NUMwrcontstart,NUMwrcontend);objects=r(1,THEmaxNumObj)" />
+    </workstage>
+
+    <workstage name="dispose">
+      <work type="dispose" workers="1" config="cprefix=THEcprefix;containers=r(NUMwrcontstart,NUMwrcontend)" />
     </workstage>
 
   </workflow>

--- a/genXML.sh
+++ b/genXML.sh
@@ -5,7 +5,7 @@
 
 # START YOUR EDITS HERE---------------------------------------
 # Use this to label your workload files
-testname="test1_"        # prepended to each XML workload name
+testname="test2_"        # prepended to each XML workload name
 #+++++++++++++
 # VARIABLES to configure workload file generation
 # Used in ALL workloads
@@ -30,6 +30,10 @@ randomWORKERS=4
 mixedWORKERS=4
 
 # TYPICALLY you will not need to edit below HERE-------------------
+
+# Calculating Container Start and End for Random/Sequential Write Workload
+numWRCONTSTART=$(( (numCONT+1) ))
+numWRCONTEND=$(( (numCONT+10) ))
 
 # We need a unique bucket name on AWS
 # generate random 20 char string (lowercase only)
@@ -113,6 +117,8 @@ declare -a THEkeys_arr=(
            "MIXEDlistConf"
            "MIXEDwrConf"
            "MIXEDdelConf"
+	   "NUMwrcontstart"
+	   "NUMwrcontend"
            )
 declare -a THEvalues_arr=(
            "${theAUTH}"          # auth credential
@@ -134,6 +140,8 @@ declare -a THEvalues_arr=(
            "${listCONF}"         # config for List operations
            "${wrCONF}"           # config for Write ops
            "${delCONF}"          # config for Delete ops
+	   "${numWRCONTSTART}"   # Start Value of Write Container
+	   "${numWRCONTEND}"     # End Value of Write Container
            )
 #
 # END VARIABLES


### PR DESCRIPTION
Amended random and sequential template files so that it will create new containers for write workload and eventually delete and dispose them within the same workflow. Modified the genXML.sh accordingly as well

Signed-off-by: Shekhar Berry <shberry@redhat.com>